### PR TITLE
Fix multiple device filters excluding all devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
-# WebDeviceMux
+# web-device-mux
+
+![NPM Version](https://img.shields.io/npm/v/web-device-mux) | [![Build](https://github.com/Cellivar/WebDeviceMux/actions/workflows/build-npm.yml/badge.svg?branch=main)](https://github.com/Cellivar/WebDeviceMux/actions/workflows/build-npm.yml)
 
 A small library for managing connections to WebUSB, WebHID, and Web Serial devices from multiple tabs at the same time.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-device-mux",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A small library for managing connections to WebUSB, WebHID, and Web Serial devices from multiple tabs at the same time.",
   "type": "module",
   "repository": {

--- a/src/Usb/UsbUtilities.test.ts
+++ b/src/Usb/UsbUtilities.test.ts
@@ -1,0 +1,154 @@
+import { test, expect, describe } from 'vitest';
+import { isManageableDevice } from './UsbUtilities.js';
+
+describe('Filter Includes Work', () => {
+  const device = {
+    vendorId: 0x1234,
+  } as USBDevice;
+  test('No filters means no device', () => {
+    const filter = {} as USBDeviceRequestOptions;
+    expect(isManageableDevice(device, filter)).toBe(false);
+  });
+
+  test('Filter mismatch excludes device', () => {
+    const filter = {
+      filters: [
+        {
+          vendorId: 0x9999,
+        }
+      ]
+    } as USBDeviceRequestOptions;
+    expect(isManageableDevice(device, filter)).toBe(false);
+  });
+
+  test('Multiple filters with all mismatch excludes device', () => {
+    const filter = {
+      filters: [
+        {
+          vendorId: 0x9999,
+        },
+        {
+          vendorId: 0x9998,
+        }
+      ]
+    } as USBDeviceRequestOptions;
+    expect(isManageableDevice(device, filter)).toBe(false);
+  });
+
+  test('Blank filter allows device', () => {
+    const filter = {
+      filters: [{}]
+    } as USBDeviceRequestOptions;
+    expect(isManageableDevice(device, filter)).toBe(true);
+  });
+
+  test('Filter match allows device', () => {
+    const filter = {
+      filters: [
+        {
+          vendorId: 0x1234,
+        }
+      ]
+    } as USBDeviceRequestOptions;
+    expect(isManageableDevice(device, filter)).toBe(true);
+  });
+
+  test('Multiple filters with some match allows device', () => {
+    const filter = {
+      filters: [
+        {
+          vendorId: 0x1234,
+        },
+        {
+          vendorId: 0x9999,
+        }
+      ]
+    } as USBDeviceRequestOptions;
+    expect(isManageableDevice(device, filter)).toBe(true);
+  });
+
+  test('Multiple filters with all match allows device', () => {
+    const filter = {
+      filters: [
+        {
+          vendorId: 0x1234,
+        },
+        {
+          vendorId: 0x1234,
+        }
+      ]
+    } as USBDeviceRequestOptions;
+    expect(isManageableDevice(device, filter)).toBe(true);
+  });
+});
+
+describe('Multiple filter fields work', () => {
+  const device = {
+    vendorId: 0x1234,
+    productId: 0xabcd,
+    deviceClass: 0x42,
+    deviceSubclass: 0x01,
+    deviceProtocol: 0x00,
+    serialNumber: '1234567890'
+  } as USBDevice;
+
+  test('Filter multiple data match includes device', () => {
+    const filter = {
+      filters: [
+        {
+          vendorId: 0x1234,
+          productId: 0xabcd,
+          classCode: 0x42,
+          subclassCode: 0x01,
+          protocolCode: 0x00,
+          serialNumber: '1234567890'
+        }
+      ]
+    } as USBDeviceRequestOptions;
+    expect(isManageableDevice(device, filter)).toBe(true);
+  });
+
+  test('Multiple filters with one valid includes device', () => {
+    const filter = {
+      filters: [
+        {
+          vendorId: 0x1234,
+          productId: 0xabcd,
+        },
+        {
+          vendorId: 0x1234,
+          productId: 0x1234,
+        }
+      ]
+    } as USBDeviceRequestOptions;
+    expect(isManageableDevice(device, filter)).toBe(true);
+  });
+
+  test('Mixed field match excludes device', () => {
+    const filter = {
+      filters: [
+        {
+          vendorId: 0x1234,
+          productId: 0x1234,
+        }
+      ]
+    } as USBDeviceRequestOptions;
+    expect(isManageableDevice(device, filter)).toBe(false);
+  });
+
+  test('Multiple mixed field mismatch excludes device', () => {
+    const filter = {
+      filters: [
+        {
+          vendorId: 0x1234,
+          productId: 0x1234,
+        },
+        {
+          vendorId: 0xabcd,
+          productId: 0xabcd,
+        }
+      ]
+    } as USBDeviceRequestOptions;
+    expect(isManageableDevice(device, filter)).toBe(false);
+  });
+});

--- a/src/Usb/UsbUtilities.ts
+++ b/src/Usb/UsbUtilities.ts
@@ -1,0 +1,47 @@
+/** Determine if a given device is allowed to be managed by this manager. */
+export function isManageableDevice(
+  device: USBDevice,
+  requestOptions: USBDeviceRequestOptions
+): boolean {
+  const filters = requestOptions.filters ?? [];
+  const exclusionFilters = requestOptions.exclusionFilters ?? [];
+
+  // Sanity check: No filters, no devices.
+  if (filters === undefined || filters.length === 0) {
+    return false;
+  }
+
+  // Step 1: Look for filters where the device doesn't match.
+  if (filters.every(f => isDeviceFilterMatchOperation(device, f, "ne") === true)) {
+    return false;
+  }
+
+  // Step 2: Look for exclusions where the device does match.
+  if (exclusionFilters.some(f => isDeviceFilterMatchOperation(device, f, "eq") === true)) {
+    return false;
+  }
+
+  // Not filtered!
+  return true;
+}
+
+type Operation = "eq" | "ne";
+
+function isDeviceFilterMatchOperation(
+  device: USBDevice,
+  filter: USBDeviceFilter,
+  operation: Operation,
+) {
+  return (filter.vendorId   !== undefined && op(operation, filter.vendorId, device.vendorId))
+    || (filter.productId    !== undefined && op(operation, filter.productId, device.productId))
+    || (filter.classCode    !== undefined && op(operation, filter.classCode, device.deviceClass))
+    || (filter.subclassCode !== undefined && op(operation, filter.subclassCode, device.deviceSubclass))
+    || (filter.protocolCode !== undefined && op(operation, filter.protocolCode, device.deviceProtocol))
+    || (filter.serialNumber !== undefined && op(operation, filter.serialNumber, device.serialNumber));
+}
+
+function op<TVal>(op: Operation, left: TVal, right: TVal) {
+  return op === "eq"
+    ? left === right
+    : left !== right
+}


### PR DESCRIPTION
The filter logic wasn't properly handling mixed results from multiple filters, such as two filters with different vendor IDs. This fixes that issue and adds some tests to ensure it works correctly.