### PR TITLE
v0.4.0 Improve performance of listening

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-device-mux",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A small library for managing connections to WebUSB, WebHID, and Web Serial devices from multiple tabs at the same time.",
   "type": "module",
   "repository": {

--- a/src/Usb/UsbDeviceChannel.ts
+++ b/src/Usb/UsbDeviceChannel.ts
@@ -31,6 +31,29 @@ function deviceToInfo(device: USBDevice): IUSBDeviceInformation {
   };
 }
 
+if (import.meta.vitest) {
+  const { it, expect, describe } = import.meta.vitest
+
+  describe('deviceToInfo', () => {
+    it('Translates all values', () => {
+      const dev = {
+        deviceClass          : 1,
+        deviceProtocol       : 2,
+        deviceSubclass       : 3,
+        deviceVersionMajor   : 4,
+        deviceVersionMinor   : 5,
+        deviceVersionSubminor: 6,
+        productId            : 7,
+        vendorId             : 8,
+        manufacturerName     : 'man',
+        productName          : 'name',
+        serialNumber         : 'ser',
+      } as unknown as USBDevice;
+      expect(deviceToInfo(dev)).toEqual(dev);
+    });
+  });
+}
+
 /** Class for managing the WebUSB communication with a device. */
 export class UsbDeviceChannel implements IDeviceChannel<Uint8Array, Uint8Array> {
   private device: USBDevice;
@@ -66,81 +89,18 @@ export class UsbDeviceChannel implements IDeviceChannel<Uint8Array, Uint8Array> 
 
   private async setup() {
     try {
-      await this.connect();
+      const endpoints = await connectDevice(this.device);
+
+      this._commMode = getCommMode(endpoints.output !== undefined, endpoints.input !== undefined);
+
+      if (this._commOptions.debug) {
+        console.debug('Comm mode with device is', ConnectionDirectionMode[this._commMode]);
+      }
     } catch {
       await this.dispose();
     }
     this._readyFlag = true;
     return true;
-  }
-
-  private async connect() {
-    const d = this.device;
-
-    // Most devices have two endpoints on one interface for bidirectional bulk
-    // in and out. The more poorly performing a device the more random this
-    // layout will be, so we must go and look for these two endpoints.
-    if (d.configurations[0]?.interfaces[0]?.alternates[0] === undefined) {
-      // Can't talk to the device at all???
-      throw new DeviceCommunicationError(
-        'USB device did not expose an endpoint to communicate with. Try power-cycling the device, or checking its settings. This is a hardware problem.'
-      );
-    }
-
-    // Open the connection! Stop having it be closed!
-    try {
-      await d.open();
-    } catch (e) {
-      if (
-        e instanceof DOMException &&
-        e.name === 'SecurityError' &&
-        e.message === "Failed to execute 'open' on 'USBDevice': Access denied."
-      ) {
-        // This can happen if something else, usually the operating system, has taken
-        // exclusive access of the USB device and won't allow WebUSB to take control.
-        // This most often happens on Windows. You can use Zadig to replace the driver.
-        throw new DriverAccessDeniedError();
-      }
-
-      throw e;
-    }
-
-    // TODO: Settings for multiple interfaces?
-    await d.selectConfiguration(1);
-    await d.claimInterface(0);
-
-    let o: USBEndpoint | undefined = undefined;
-    let i: USBEndpoint | undefined = undefined;
-    for (const endpoint of d.configurations[0].interfaces[0].alternates[0].endpoints) {
-      if (endpoint.direction == 'out') {
-        o = endpoint;
-      } else if (endpoint.direction == 'in') {
-        i = endpoint;
-      }
-    }
-
-    // For no apparent reason sometimes devices will omit to advertise the
-    // input endpoint. Sometimes they'll also omit the output endpoint. This
-    // attempts to handle those situations in a degraded mode.
-    if (!o) {
-      throw new DeviceCommunicationError(
-        'USB device did not expose an output endpoint. Try power-cycling the device. This is a hardware problem.'
-      );
-    } else {
-      this.deviceOut = o;
-    }
-
-    if (!i) {
-      console.warn('USB device did not expose an input endpoint, using unidirectional mode.');
-    } else {
-      this.deviceIn = i;
-    }
-
-    this._commMode = this.getCommMode(this.deviceOut !== undefined, this.deviceIn !== undefined);
-
-    if (this._commOptions.debug) {
-      console.debug('Comm mode with device is', ConnectionDirectionMode[this._commMode]);
-    }
   }
 
   public async dispose() {
@@ -240,20 +200,131 @@ export class UsbDeviceChannel implements IDeviceChannel<Uint8Array, Uint8Array> 
 
     return [new Uint8Array(result.data.buffer, result.data.byteOffset, result.data.byteLength)];
   }
+}
 
-  private getCommMode(output: boolean, input: boolean) {
-    // TODO: Figure out if getting the Interface Protocol Mode is more
-    // reliable than the detection method used here...
-    if (output === false) {
-      // Can't talk to something that isn't listening...
-      return ConnectionDirectionMode.none;
-    }
-    if (input === false) {
-      // Can send commands but can't get info back. Operating in the blind.
-      return ConnectionDirectionMode.unidirectional;
-    }
-    return ConnectionDirectionMode.bidirectional;
+async function connectDevice(d: USBDevice) {
+  // Most devices have two endpoints on one interface for bidirectional bulk
+  // in and out. The more poorly performing a device the more random this
+  // layout will be, so we must go and look for these two endpoints.
+  if (d.configurations[0]?.interfaces[0]?.alternates[0] === undefined) {
+    // Can't talk to the device at all???
+    throw new DeviceCommunicationError(
+      'USB device did not expose an endpoint to communicate with. Try power-cycling the device, or checking its settings. This is a hardware problem.'
+    );
   }
+
+  // Open the connection! Stop having it be closed!
+  try {
+    await d.open();
+  } catch (e) {
+    if (
+      e instanceof DOMException &&
+      e.name === 'SecurityError' &&
+      e.message === "Failed to execute 'open' on 'USBDevice': Access denied."
+    ) {
+      // This can happen if something else, usually the operating system, has taken
+      // exclusive access of the USB device and won't allow WebUSB to take control.
+      // This most often happens on Windows. You can use Zadig to replace the driver.
+      throw new DriverAccessDeniedError();
+    }
+
+    throw e;
+  }
+
+  // TODO: Settings for multiple interfaces?
+  await d.selectConfiguration(1);
+  await d.claimInterface(0);
+
+  let o: USBEndpoint | undefined = undefined;
+  let i: USBEndpoint | undefined = undefined;
+  for (const endpoint of d.configurations[0].interfaces[0].alternates[0].endpoints) {
+    if (endpoint.direction == 'out') {
+      o = endpoint;
+    } else if (endpoint.direction == 'in') {
+      i = endpoint;
+    }
+  }
+
+  // For no apparent reason sometimes devices will omit to advertise the
+  // input endpoint. Sometimes they'll also omit the output endpoint. This
+  // attempts to handle those situations in a degraded mode.
+  if (!o) {
+    throw new DeviceCommunicationError(
+      'USB device did not expose an output endpoint. Try power-cycling the device. This is a hardware problem.'
+    );
+  }
+
+  if (!i) {
+    console.warn('USB device did not expose an input endpoint, using unidirectional mode.');
+  }
+
+  return {input: i, output: o}
+}
+
+if (import.meta.vitest) {
+  const { it, expect, describe } = import.meta.vitest;
+
+  describe('connectDevice', () => {
+    it('Throws on no endpoint', async () => {
+      const badDevice: USBDevice = {
+        configurations: []
+      } as unknown as USBDevice;
+      await expect(() => connectDevice(badDevice)).rejects.toThrowError();
+    });
+
+    it('Throws on access denied', async () => {
+      // This is thrown if the operating system won't let the browser talk to
+      // the device directly.
+      const accessException = new DOMException(
+        "Failed to execute 'open' on 'USBDevice': Access denied.",
+        'SecurityError'
+      );
+      const badDevice: USBDevice = {
+        configurations: [
+          {
+            interfaces: [
+              {
+                alternates: [
+                  {}
+                ]
+              }
+            ]
+          }
+        ],
+        open() {
+          throw accessException;
+        },
+      } as unknown as USBDevice;
+      await expect(() => connectDevice(badDevice)).rejects.toThrow(new DriverAccessDeniedError());
+    });
+  });
+}
+
+function getCommMode(output: boolean, input: boolean) {
+  // TODO: Figure out if getting the Interface Protocol Mode is more
+  // reliable than the detection method used here...
+  if (output === false) {
+    // Can't talk to something that isn't listening...
+    return ConnectionDirectionMode.none;
+  }
+  if (input === false) {
+    // Can send commands but can't get info back. Operating in the blind.
+    return ConnectionDirectionMode.unidirectional;
+  }
+  return ConnectionDirectionMode.bidirectional;
+}
+
+if (import.meta.vitest) {
+  const { it, expect, describe } = import.meta.vitest
+
+  describe('getCommMode', () => {
+    it('Gets sane result', () => {
+      expect(getCommMode(false, false)).toBe(ConnectionDirectionMode.none);
+      expect(getCommMode(false, true)).toBe(ConnectionDirectionMode.none);
+      expect(getCommMode(true, false)).toBe(ConnectionDirectionMode.unidirectional);
+      expect(getCommMode(true, true)).toBe(ConnectionDirectionMode.bidirectional);
+    });
+  });
 }
 
 /** Error indicating the devices's driver cannot be used by WebUSB. */

--- a/src/Usb/UsbDeviceChannel.ts
+++ b/src/Usb/UsbDeviceChannel.ts
@@ -165,11 +165,12 @@ export class UsbDeviceChannel implements IDeviceChannel<Uint8Array, Uint8Array> 
     return deviceToInfo(this.device);
   }
 
-  public async getInput(): Promise<Uint8Array[] | DeviceNotReadyError> {
+  public async getInput(packetSizeMultiplier: number = 16): Promise<Uint8Array[] | DeviceNotReadyError> {
     if (this.deviceIn === undefined || !this.connected) { return new DeviceNotReadyError('Channel is not connected.'); }
     const result = await this.device.transferIn(
       this.deviceIn.endpointNumber,
-      this.deviceIn.packetSize * 8, // Usually 64 * 8 = 512
+      //
+      this.deviceIn.packetSize * packetSizeMultiplier, // Usually 64 * 8 = 512
     )
     .catch((error: unknown) => {
       if (error instanceof DOMException

--- a/src/Usb/UsbUtilities.test.ts
+++ b/src/Usb/UsbUtilities.test.ts
@@ -1,16 +1,16 @@
-import { test, expect, describe } from 'vitest';
+import { it, expect, describe } from 'vitest';
 import { isManageableDevice } from './UsbUtilities.js';
 
 describe('Filter Includes Work', () => {
   const device = {
     vendorId: 0x1234,
   } as USBDevice;
-  test('No filters means no device', () => {
+  it('No filters means no device', () => {
     const filter = {} as USBDeviceRequestOptions;
     expect(isManageableDevice(device, filter)).toBe(false);
   });
 
-  test('Filter mismatch excludes device', () => {
+  it('Filter mismatch excludes device', () => {
     const filter = {
       filters: [
         {
@@ -21,7 +21,7 @@ describe('Filter Includes Work', () => {
     expect(isManageableDevice(device, filter)).toBe(false);
   });
 
-  test('Multiple filters with all mismatch excludes device', () => {
+  it('Multiple filters with all mismatch excludes device', () => {
     const filter = {
       filters: [
         {
@@ -35,14 +35,14 @@ describe('Filter Includes Work', () => {
     expect(isManageableDevice(device, filter)).toBe(false);
   });
 
-  test('Blank filter allows device', () => {
+  it('Blank filter allows device', () => {
     const filter = {
       filters: [{}]
     } as USBDeviceRequestOptions;
     expect(isManageableDevice(device, filter)).toBe(true);
   });
 
-  test('Filter match allows device', () => {
+  it('Filter match allows device', () => {
     const filter = {
       filters: [
         {
@@ -53,7 +53,7 @@ describe('Filter Includes Work', () => {
     expect(isManageableDevice(device, filter)).toBe(true);
   });
 
-  test('Multiple filters with some match allows device', () => {
+  it('Multiple filters with some match allows device', () => {
     const filter = {
       filters: [
         {
@@ -67,7 +67,7 @@ describe('Filter Includes Work', () => {
     expect(isManageableDevice(device, filter)).toBe(true);
   });
 
-  test('Multiple filters with all match allows device', () => {
+  it('Multiple filters with all match allows device', () => {
     const filter = {
       filters: [
         {
@@ -92,7 +92,7 @@ describe('Multiple filter fields work', () => {
     serialNumber: '1234567890'
   } as USBDevice;
 
-  test('Filter multiple data match includes device', () => {
+  it('Filter multiple data match includes device', () => {
     const filter = {
       filters: [
         {
@@ -108,7 +108,7 @@ describe('Multiple filter fields work', () => {
     expect(isManageableDevice(device, filter)).toBe(true);
   });
 
-  test('Multiple filters with one valid includes device', () => {
+  it('Multiple filters with one valid includes device', () => {
     const filter = {
       filters: [
         {
@@ -124,7 +124,7 @@ describe('Multiple filter fields work', () => {
     expect(isManageableDevice(device, filter)).toBe(true);
   });
 
-  test('Mixed field match excludes device', () => {
+  it('Mixed field match excludes device', () => {
     const filter = {
       filters: [
         {
@@ -136,7 +136,7 @@ describe('Multiple filter fields work', () => {
     expect(isManageableDevice(device, filter)).toBe(false);
   });
 
-  test('Multiple mixed field mismatch excludes device', () => {
+  it('Multiple mixed field mismatch excludes device', () => {
     const filter = {
       filters: [
         {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,9 @@
 {
   "compilerOptions": {
+    "types": [
+      "vitest/importMeta",
+      "@types/w3c-web-usb"
+    ],
     "target": "ES2022",
     "module": "nodenext",
     "moduleResolution": "nodenext",


### PR DESCRIPTION
In testing I discovered a couple of things:

* Printers sometimes will provide much bigger transfer sizes if you offer them. 
* Being able to detect a printer is taking a while to respond is useful.

This adds features for both. 

getInput now has an optional parameter to increase the requested message size.

There is now an event loop in the listener promise, every 500ms it can run checks before resuming awaiting the same promise for input. This may get additional features in the future.

Also more tests.