### PR TITLE
v0.5: Deprecate async-ish constructor, use better names for send/receive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-device-mux",
-  "version": "0.3.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-device-mux",
-      "version": "0.3.0",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@eslint/js": "^9.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-device-mux",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "A small library for managing connections to WebUSB, WebHID, and Web Serial devices from multiple tabs at the same time.",
   "type": "module",
   "repository": {

--- a/src/Channel.ts
+++ b/src/Channel.ts
@@ -21,7 +21,16 @@ export interface IDeviceCommunicationOptions {
   debug: boolean;
 
   /** Milliseconds to wait for messages from a device before assuming it's done talking. Defaults to 500ms. */
-  messageWaitTimeoutMS?: number
+  messageWaitTimeoutMS?: number;
+
+  /**
+   * Max receive packet size, in bytes. Should be a power of two, 512, 1024, etc.
+   *
+   * Not all devices will respect this number. This value will be rounded down
+   * to the nearest packet size if the device must transmit on a specific length
+   * boundary. For example, most USB devices use multiples of 64.
+   */
+  maxReceivePacketSize?: number;
 }
 
 /** A communication channel for talking to a device. */

--- a/src/Channel.ts
+++ b/src/Channel.ts
@@ -41,9 +41,6 @@ export interface IDeviceChannel<TOutput, TInput> {
   /** Gets this channel type. */
   readonly channelType: DeviceChannelType;
 
-  /** A promise indicating this communication channel is ready for use. */
-  get ready(): Promise<boolean>;
-
   /** Whether the device is connected. */
   get connected(): boolean;
 
@@ -51,7 +48,7 @@ export interface IDeviceChannel<TOutput, TInput> {
   dispose(): Promise<void>;
 
   /** Gets the basic information for the device connected on this channel. */
-  getDeviceInfo(): IDeviceInformation
+  getDeviceInfo(): Promise<IDeviceInformation>;
 
   /**
    * Send a series of commands to the device.

--- a/src/Channel.ts
+++ b/src/Channel.ts
@@ -51,11 +51,11 @@ export interface IDeviceChannel<TOutput, TInput> {
   getDeviceInfo(): Promise<IDeviceInformation>;
 
   /**
-   * Send a series of commands to the device.
-   * @param commandBuffer The series of commands to send in order.
+   * Send data to the device.
+   * @param data The buffer of data to send to the device.
    */
-  sendCommands(commandBuffer: TOutput): Promise<DeviceCommunicationError | undefined>;
+  send(data: TOutput): Promise<DeviceCommunicationError | undefined>;
 
   /** Request data from the device. */
-  getInput(): Promise<TInput[] | DeviceCommunicationError>;
+  receive(): Promise<TInput[] | DeviceCommunicationError>;
 }

--- a/src/InputListener.test.ts
+++ b/src/InputListener.test.ts
@@ -1,16 +1,19 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { it, expect, describe } from 'vitest';
-import { InputMessageListener, type InputHandler } from './InputListener.js';
+import { InputMessageListener, type InputErrorHandler, type InputHandler } from './InputListener.js';
 import { DeviceCommunicationError } from './Error.js';
 
 function getValidListener(
-  callback: InputHandler<string> = (i) => { console.log(i); return Promise.resolve({}); }
+  callback: InputHandler<string> = (i) => { console.log(i); return Promise.resolve({}); },
+  errorHandler: InputErrorHandler = (e) => { console.log(e); return Promise.resolve(); }
 ) {
   return new InputMessageListener<string>(
     async () => {
       await new Promise(resolve => setTimeout(resolve, 50));
       return ['hello'];
     },
-    callback
+    callback,
+    errorHandler
   );
 }
 
@@ -19,7 +22,8 @@ function getErrorListener() {
     async () => {
       return new DeviceCommunicationError("This is a test error");
     },
-    async (input) => { return {remainderData: input}}
+    async (input) => { return {remainderData: input} },
+    (_) => { return Promise.resolve(); }
   );
 }
 
@@ -31,7 +35,8 @@ function getSlowListener(
       await new Promise(resolve => setTimeout(resolve, 510));
       return ['hello, but slowly.'];
     },
-    callback
+    callback,
+    (_) => { return Promise.resolve(); }
   );
 }
 

--- a/src/InputListener.ts
+++ b/src/InputListener.ts
@@ -1,9 +1,10 @@
 // TODO: Rewrite the entire message handling system as a stream transformer?
 
-import { DeviceCommunicationError } from "./Error.js";
+import { DeviceCommunicationError, WebDeviceMuxError } from "./Error.js";
 
 export type DataProvider<TInput> = () => Promise<TInput[] | DeviceCommunicationError>;
 export type InputHandler<TInput> = (input: TInput[]) => Promise<IHandlerResponse<TInput>>;
+export type InputErrorHandler = (error: DeviceCommunicationError) => Promise<void>;
 export interface IHandlerResponse<TInput> {
   remainderData?: TInput[];
 }
@@ -32,55 +33,65 @@ export class InputMessageListener<TInput> {
     // the calling function to be async. The promise we're starting is meant to
     // run forever and never resolve until it's being shut down.
     // eslint-disable-next-line no-async-promise-executor
-    new Promise<void>(async (_, reject) => {
+    new Promise<void>(async (_, reject: (e: DeviceCommunicationError) => void) => {
       let aggregate: TInput[] = [];
       let inputPromise: undefined | Promise<TInput[] | DeviceCommunicationError> = undefined;
-      do {
-        // Allow resuming awaiting an already-in-progress promise.
-        inputPromise ??= this._dataProvider();
-        const data = await promiseWithTimeoutDefault(inputPromise, 500, listenSentinel);
+      try {
+        do {
+          // Allow resuming awaiting an already-in-progress promise.
+          inputPromise ??= this._dataProvider();
+          const data = await promiseWithTimeoutDefault(inputPromise, 500, listenSentinel);
 
-        // Printers can idle or otherwise not response for long periods of time.
-        // We have a little event loop here, where every 500 milliseconds we
-        // can do some housekeeping to see if we should continue waiting or give
-        // up entirely.
-        if (data === listenSentinel) {
-          continue;
+          // Printers can idle or otherwise not response for long periods of time.
+          // We have a little event loop here, where every 500 milliseconds we
+          // can do some housekeeping to see if we should continue waiting or give
+          // up entirely.
+          if (data === listenSentinel) {
+            continue;
+          } else {
+            // This indicates we've left our event loop and got a real result.
+            inputPromise = undefined;
+          }
+
+          if (data instanceof DeviceCommunicationError) {
+            reject(data);
+            break;
+          }
+
+          if (data.length === 0) {
+            continue;
+          }
+
+          aggregate.push(...data);
+          this.logIfDebug(`Got data from provider, now has ${aggregate.length} items in receive buffer. Data: `, data);
+
+          // The handler determines if what we got was sufficient, or if we need more.
+          const handleResult = await this._inputHandler(aggregate);
+          if (handleResult.remainderData !== undefined && handleResult.remainderData.length !== 0) {
+            this.logIfDebug(`Input handler provided a ${handleResult.remainderData.length} length incomplete buffer.`);
+          }
+
+          // The handler is not required to be stateful, this is instead.
+          // The handler may indicate more data is expected by returning incomplete
+          // data back. We prefix our buffer with that incomplete data to add more
+          // to it and wait again for more.
+          aggregate = handleResult.remainderData ?? [];
+        } while (!this._disposed);
+      } catch (e: unknown) {
+        if (e instanceof DeviceCommunicationError) {
+          reject(e);
+        } else if (e instanceof WebDeviceMuxError || e instanceof Error) {
+          reject(new DeviceCommunicationError(`Exception thrown listening to input.`, e));
         } else {
-          // This indicates we've left our event loop and got a real result.
-          inputPromise = undefined;
+          console.error(`Encountered unexpected exception from input listener, this is a bug in the WebDeviceMux library.\n`, e);
+          throw e;
         }
-
-        if (data instanceof DeviceCommunicationError) {
-          console.error(`Error getting data from source: `, data);
-          reject(data);
-          break;
-        }
-
-        if (data.length === 0) {
-          continue;
-        }
-
-        aggregate.push(...data);
-        this.logIfDebug(`Got data from provider, now has ${aggregate.length} items in receive buffer. Data: `, data);
-
-        // The handler determines if what we got was sufficient, or if we need more.
-        const handleResult = await this._inputHandler(aggregate);
-        if (handleResult.remainderData !== undefined && handleResult.remainderData.length !== 0) {
-          this.logIfDebug(`Input handler provided a ${handleResult.remainderData.length} length incomplete buffer.`);
-        }
-
-        // The handler is not required to be stateful, this is instead.
-        // The handler may indicate more data is expected by returning incomplete
-        // data back. We prefix our buffer with that incomplete data to add more
-        // to it and wait again for more.
-        aggregate = handleResult.remainderData ?? [];
-      } while (!this._disposed);
+      }
     })
-    .catch((reason) => {
-      // TODO: Better logging?
+    .catch(async (reason) => {
       this._disposed = true;
       this.logIfDebug(`Device stream listener stopped listening unexpectedly.`, reason);
+      await this._errorHandler(reason);
     });
   }
 
@@ -93,6 +104,7 @@ export class InputMessageListener<TInput> {
   constructor(
     private readonly _dataProvider: DataProvider<TInput>,
     private readonly _inputHandler: InputHandler<TInput>,
+    private readonly _errorHandler: InputErrorHandler,
     private readonly _debugLogging: boolean = true, // TODO: false
   ) {}
 

--- a/src/Usb/UsbDeviceChannel.test.ts
+++ b/src/Usb/UsbDeviceChannel.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { it, expect, describe } from 'vitest';
-import { UsbDeviceChannel } from './UsbDeviceChannel.js';
+import { DriverAccessDeniedError, UsbDeviceChannel } from './UsbDeviceChannel.js';
 
 type deviceThrows
 = 'none'
@@ -130,10 +130,17 @@ function getFakeDevice(
 
 describe('UsbDeviceChannel', () => {
   it('Constructs and sets fields', async () => {
-    const channel = new UsbDeviceChannel(getFakeDevice(), { debug: true });
-    await channel.ready;
+    const channel = await UsbDeviceChannel.fromDevice(getFakeDevice(), { debug: true });
     expect(channel['_disposed']).toBe(false);
     expect(channel['deviceIn']).not.toBeUndefined();
     expect(channel['deviceOut']).not.toBeUndefined();
+  });
+
+  it('Throws security error', async () => {
+    const dev = getFakeDevice('openSecurity');
+    await expect(async () => {
+      const channel = await UsbDeviceChannel.fromDevice(dev);
+      channel.dispose();
+    }).rejects.toThrowError(new DriverAccessDeniedError());
   });
 });

--- a/src/Usb/UsbDeviceChannel.ts
+++ b/src/Usb/UsbDeviceChannel.ts
@@ -149,7 +149,7 @@ export class UsbDeviceChannel implements IDeviceChannel<Uint8Array, Uint8Array> 
     }
   }
 
-  public async sendCommands(
+  public async send(
     commandBuffer: Uint8Array
   ): Promise<DeviceNotReadyError | undefined> {
     if (this.deviceOut === undefined || !this.connected) {
@@ -186,7 +186,7 @@ export class UsbDeviceChannel implements IDeviceChannel<Uint8Array, Uint8Array> 
     return Promise.resolve(deviceToInfo(this.device));
   }
 
-  public async getInput(packetSizeMultiplier: number = 16): Promise<Uint8Array[] | DeviceNotReadyError> {
+  public async receive(): Promise<Uint8Array[] | DeviceNotReadyError> {
     if (this.deviceIn === undefined || !this.connected) { return new DeviceNotReadyError('Channel is not connected.'); }
 
     const result = await this.device.transferIn(


### PR DESCRIPTION
Relevant changes:

* Make UsbDeviceChannel constructor protected, add async fromDevice factory method instead.
* Add error handler callback for InputListener.
* Add maxReceivePacketSize option to comm options, to better control receive sizes.
* Rename sendCommands to send
* Rename getInput to receive

On the path towards 1.0 making the API easier to use and extend!